### PR TITLE
Use upstream provided basedir

### DIFF
--- a/packages/sile-logos/init.lua
+++ b/packages/sile-logos/init.lua
@@ -3,22 +3,16 @@ local base = require("packages.base")
 local package = pl.class(base)
 package._name = "sile-logos"
 
-local function script_path ()
-   local str = debug.getinfo(2, "S").source:sub(2)
-   return str:match("(.*/)")
-end
-
 function package:_init ()
 	base._init(self)
 end
 
 function package:registerCommands ()
-	base.registerCommands(self)
 	-- The first iteration of this package was a collection of commands
 	-- registered using \define{} macros in the SIL input format. They should
 	-- probably be refactored using Lua, but to get the party started with SILE
 	-- v0.13 package support we'll just process them here.
-	SILE.processFile(script_path() .. "macros.sil")
+	SILE.processFile(self.basedir .. "macros.sil")
 end
 
 return package


### PR DESCRIPTION
I realized while working on this package that *a lot* of packages may end up needing the same directory discovery logic, so I upstreamed it to SILE so every package author doesn't have to reinvent the same wheel.

https://github.com/sile-typesetter/sile/pull/1529

I'll leave this in draft mode until the interface is in a released version.
